### PR TITLE
[FIX] JMS message retrieval fails for JMS 1.x unsupported properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Add observability support to the JMS module](https://github.com/ballerina-platform/ballerina-library/issues/5932)
 
+### Fixed
+- [JMS message retrieval fails for JMS 1.x unsupported properties](https://github.com/ballerina-platform/ballerina-library/issues/6204)
+
 ## [0.1.0] - 2023-07-24
 
 ### Changed

--- a/native/src/main/java/io/ballerina/stdlib/java.jms/CommonUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/java.jms/CommonUtils.java
@@ -117,7 +117,12 @@ public class CommonUtils {
         ballerinaMessage.put(Constants.REDELIVERED, message.getJMSRedelivered());
         ballerinaMessage.put(Constants.JMS_TYPE, StringUtils.fromString(message.getJMSType()));
         ballerinaMessage.put(Constants.EXPIRATION, message.getJMSExpiration());
-        ballerinaMessage.put(Constants.DELIVERED_TIME, message.getJMSDeliveryTime());
+        try {
+            ballerinaMessage.put(Constants.DELIVERED_TIME, message.getJMSDeliveryTime());
+        } catch (UnsupportedOperationException e) {
+            // This exception occurs when the client connect to a JMS provider who supports JMS 1.x.
+            // Hence, ignoring this exception.
+        }
         ballerinaMessage.put(Constants.PRIORITY, message.getJMSPriority());
         ballerinaMessage.put(Constants.PROPERTIES, getMessageProperties(message));
         Object content = getMessageContent(message);

--- a/native/src/main/java/io/ballerina/stdlib/java.jms/CommonUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/java.jms/CommonUtils.java
@@ -106,7 +106,9 @@ public class CommonUtils {
         BMap<BString, Object> ballerinaMessage = ValueCreator.createRecordValue(ModuleUtils.getModule(), messageType);
         ballerinaMessage.put(Constants.MESSAGE_ID, StringUtils.fromString(message.getJMSMessageID()));
         ballerinaMessage.put(Constants.TIMESTAMP, message.getJMSTimestamp());
-        ballerinaMessage.put(Constants.CORRELATION_ID, StringUtils.fromString(message.getJMSCorrelationID()));
+        if (Objects.nonNull(message.getJMSCorrelationID())) {
+            ballerinaMessage.put(Constants.CORRELATION_ID, StringUtils.fromString(message.getJMSCorrelationID()));
+        }
         if (Objects.nonNull(message.getJMSReplyTo())) {
             ballerinaMessage.put(Constants.REPLY_TO, getJmsDestinationField(message.getJMSReplyTo()));
         }
@@ -115,7 +117,9 @@ public class CommonUtils {
         }
         ballerinaMessage.put(Constants.DELIVERY_MODE, message.getJMSDeliveryMode());
         ballerinaMessage.put(Constants.REDELIVERED, message.getJMSRedelivered());
-        ballerinaMessage.put(Constants.JMS_TYPE, StringUtils.fromString(message.getJMSType()));
+        if (Objects.nonNull(message.getJMSType())) {
+            ballerinaMessage.put(Constants.JMS_TYPE, StringUtils.fromString(message.getJMSType()));
+        }
         ballerinaMessage.put(Constants.EXPIRATION, message.getJMSExpiration());
         try {
             ballerinaMessage.put(Constants.DELIVERED_TIME, message.getJMSDeliveryTime());


### PR DESCRIPTION
## Purpose
> $subject

Fixes [#6204](https://github.com/ballerina-platform/ballerina-library/issues/6204)

## Examples
N/A

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [X] Checked native-image compatibility
